### PR TITLE
allow empty input and return None

### DIFF
--- a/databank/utils.py
+++ b/databank/utils.py
@@ -51,5 +51,7 @@ def serialize_param(param: Any) -> Value:
         return param
     elif isinstance(param, (dict, list)):
         return json.dumps(param)
+    elif param is None:
+        return None
     else:
         raise ValueError(f"{type(param)} is not serializable")


### PR DESCRIPTION
Allow empty inputs to serializing util function.
This allows reading from an API which could include empty values and still return a valid format for databases.