### PR TITLE
add date format

### DIFF
--- a/databank/utils.py
+++ b/databank/utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, date
 from typing import Any, Mapping, Optional, Union
 
 from sqlalchemy import text
@@ -7,7 +7,7 @@ from sqlalchemy.engine.interfaces import Dialect
 from sqlalchemy.sql.elements import TextClause
 
 # supported types for a row value
-Value = Union[str, int, float, bool, tuple, datetime]
+Value = Union[str, int, float, bool, tuple, datetime, date]
 
 def serialize_params(params: dict[str, Any]) -> dict[str, Value]:
     """Serialize the given parameters to supported data types.
@@ -51,7 +51,7 @@ def serialize_param(param: Any) -> Value:
     Value
         Serialized parameter.
     """
-    if isinstance(param, (str, int, float, bool, tuple, datetime)):
+    if isinstance(param, (str, int, float, bool, tuple, datetime, date)):
         return param
     elif isinstance(param, (dict, list)):
         return json.dumps(param)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,5 @@
 import json
-from datetime import datetime
+from datetime import datetime, date
 
 from databank.utils import compile_sql, serialize_param
 
@@ -13,6 +13,7 @@ def test_serialize_param():
     assert serialize_param([0]) == json.dumps([0])
     assert serialize_param(datetime(1970, 1, 1)) == datetime(1970, 1, 1)
     assert serialize_param((0, 1, 2)) == (0, 1, 2)
+    assert serialize_param(date(1970, 1, 1)) == date(1970, 1, 1)
 
 
 def test_compile_sql():


### PR DESCRIPTION
I would like to add support for the datetime.date format.
According to https://docs.sqlalchemy.org/en/14/core/type_basics.html#generic-camelcase-types
directly adding the date type should work?